### PR TITLE
Put discovery service behind ingress

### DIFF
--- a/hack/deployment.yml
+++ b/hack/deployment.yml
@@ -16,7 +16,7 @@ spec:
         app: discovery
     spec:
       containers:                    
-        - image: gcr.io/storageos-public-service/discovery:0.1.4
+        - image: gcr.io/storageos-public-service/discovery:0.1.14
           imagePullPolicy: Always 
           name: discovery
           command: ["/bin/discovery"]
@@ -27,12 +27,14 @@ spec:
               value: "80"  
             - name: DATABASE_PATH
               value: /db  
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /health
               port: 80
-            initialDelaySeconds: 30
+            periodSeconds: 5
             timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           volumeMounts:          
           - name: cluster-db
             mountPath: /db

--- a/hack/ingress.yml
+++ b/hack/ingress.yml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata: 
+  name: discovery-ingress
+  namespace: default
+  annotations:
+      kubernetes.io/ingress.global-static-ip-name: content-balancer
+spec:
+  rules:
+  - host: discovery.storageos.cloud
+    http:
+      paths:
+      - backend: 
+          serviceName: discovery
+          servicePort: 80

--- a/hack/svc.yml
+++ b/hack/svc.yml
@@ -17,5 +17,4 @@ items:
     selector:
       app: discovery
     sessionAffinity: None
-    type: LoadBalancer
-    loadBalancerIP: 35.189.234.67
+    type: NodePort


### PR DESCRIPTION
Changed deployment type from LoadBalancer to a NodePort so that it can
be exposed by the ingress and content-balanced on hostname. Added
readiness probe and removed liveness probe.