### PR TITLE
DEV-2292: Improve error handling.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"sync"
 	"time"
@@ -15,9 +14,11 @@ import (
 
 // node registration errors
 var (
-	ErrAddressMissing = errors.New("node address missing")
-	ErrInvalidAddress = errors.New("invalid node address")
-	ErrNameMissing    = errors.New("node name missing")
+	ErrAddressMissing     = errors.New("node address missing")
+	ErrInvalidAddress     = errors.New("invalid node address")
+	ErrNameMissing        = errors.New("node name missing")
+	ErrNodeNamePresent    = errors.New("node name already present")
+	ErrNodeAddressPresent = errors.New("node address already present")
 )
 
 // Manager - cluster manager
@@ -129,11 +130,11 @@ func (m *DefaultManager) RegisterNode(clusterID string, node *types.Node) (updat
 		}
 
 		if n.Name == node.Name {
-			return nil, fmt.Errorf("node with name %s already exists in cluster %s", node.Name, clusterID)
+			return nil, ErrNodeNamePresent
 		}
 
 		if n.AdvertiseAddress == node.AdvertiseAddress {
-			return nil, fmt.Errorf("node with advertise addressP %s already exists in cluster %s", node.AdvertiseAddress, clusterID)
+			return nil, ErrNodeAddressPresent
 		}
 	}
 

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/storageos/discovery/cluster"
+	"github.com/storageos/discovery/store/boltdb"
+	"github.com/storageos/discovery/util/codecs"
+	"github.com/storageos/discovery/util/uuid"
+)
+
+type TestServer struct {
+	path   string
+	server *Server
+	store  *boltdb.Store
+}
+
+func setupTestServer(t *testing.T) *TestServer {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal("could not get free port to run test server on")
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	if err := listener.Close(); err != nil {
+		t.Fatalf("couldn't close listener: %v", err)
+	}
+
+	file, err := ioutil.TempFile("", "discovery-test-"+uuid.Generate())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := boltdb.New(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm := cluster.New(store, codecs.DefaultSerializer())
+
+	server := NewServer(port, cm)
+
+	return &TestServer{
+		path:   file.Name(),
+		server: server,
+		store:  store,
+	}
+}
+
+func teardownTestServer(t *testing.T, s *TestServer) {
+	s.store.Close()
+	os.Remove(s.path)
+}

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"io/ioutil"
-	"net"
 	"os"
 	"testing"
 
@@ -19,17 +18,6 @@ type TestServer struct {
 }
 
 func setupTestServer(t *testing.T) *TestServer {
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatal("could not get free port to run test server on")
-	}
-
-	port := listener.Addr().(*net.TCPAddr).Port
-
-	if err := listener.Close(); err != nil {
-		t.Fatalf("couldn't close listener: %v", err)
-	}
-
 	file, err := ioutil.TempFile("", "discovery-test-"+uuid.Generate())
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +30,7 @@ func setupTestServer(t *testing.T) *TestServer {
 
 	cm := cluster.New(store, codecs.DefaultSerializer())
 
-	server := NewServer(port, cm)
+	server := NewServer(1, cm)
 
 	return &TestServer{
 		path:   file.Name(),

--- a/handlers/nodes.go
+++ b/handlers/nodes.go
@@ -71,10 +71,10 @@ func (s *Server) registerNodeHandler(w http.ResponseWriter, r *http.Request) {
 			httperror.Error(w, r, err.Error(), http.StatusBadRequest, newCounter)
 			return
 		case cluster.ErrNodeNamePresent:
-			httperror.Error(w, r, err.Error()+fmt.Sprintf(": name %s exists in cluster %s", node.Name, clusterID), http.StatusConflict, newCounter)
+			httperror.Error(w, r, err.Error()+fmt.Sprintf(": name %s exists in cluster %s", node.Name, clusterID), http.StatusUnprocessableEntity, newCounter)
 			return
 		case cluster.ErrNodeAddressPresent:
-			httperror.Error(w, r, err.Error()+fmt.Sprintf(": address %s exists in cluster %s", node.AdvertiseAddress, clusterID), http.StatusConflict, newCounter)
+			httperror.Error(w, r, err.Error()+fmt.Sprintf(": address %s exists in cluster %s", node.AdvertiseAddress, clusterID), http.StatusUnprocessableEntity, newCounter)
 			return
 		}
 

--- a/handlers/nodes.go
+++ b/handlers/nodes.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -66,8 +67,14 @@ func (s *Server) registerNodeHandler(w http.ResponseWriter, r *http.Request) {
 		case store.ErrNotFound:
 			httperror.Error(w, r, err.Error(), http.StatusNotFound, newCounter)
 			return
-		case cluster.ErrAddressMissing, cluster.ErrInvalidAddress, cluster.ErrAddressMissing:
+		case cluster.ErrAddressMissing, cluster.ErrInvalidAddress, cluster.ErrNameMissing:
 			httperror.Error(w, r, err.Error(), http.StatusBadRequest, newCounter)
+			return
+		case cluster.ErrNodeNamePresent:
+			httperror.Error(w, r, err.Error()+fmt.Sprintf(": name %s exists in cluster %s", node.Name, clusterID), http.StatusConflict, newCounter)
+			return
+		case cluster.ErrNodeAddressPresent:
+			httperror.Error(w, r, err.Error()+fmt.Sprintf(": address %s exists in cluster %s", node.AdvertiseAddress, clusterID), http.StatusConflict, newCounter)
 			return
 		}
 

--- a/handlers/nodes_test.go
+++ b/handlers/nodes_test.go
@@ -60,7 +60,7 @@ func TestRegisterNodeHandler(t *testing.T) {
 			name:      "name already present - node 4",
 			clusterID: c.ID,
 			node:      types.Node{ID: "5", Name: "node4", AdvertiseAddress: "192.168.0.5", CreatedAt: time.Now(), UpdatedAt: time.Now()},
-			code:      http.StatusConflict,
+			code:      http.StatusUnprocessableEntity,
 			errMsg: fmt.Sprintf(
 				"%s: name node4 exists in cluster %s\n",
 				cluster.ErrNodeNamePresent,
@@ -71,7 +71,7 @@ func TestRegisterNodeHandler(t *testing.T) {
 			name:      "address already present - 192.168.0.4",
 			clusterID: c.ID,
 			node:      types.Node{ID: "6", Name: "node6", AdvertiseAddress: "192.168.0.4", CreatedAt: time.Now(), UpdatedAt: time.Now()},
-			code:      http.StatusConflict,
+			code:      http.StatusUnprocessableEntity,
 			errMsg: fmt.Sprintf(
 				"%s: address 192.168.0.4 exists in cluster %s\n",
 				cluster.ErrNodeAddressPresent,

--- a/handlers/nodes_test.go
+++ b/handlers/nodes_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/storageos/discovery/cluster"
+	"github.com/storageos/discovery/store"
+	"github.com/storageos/discovery/types"
+)
+
+func TestRegisterNodeHandler(t *testing.T) {
+	srv := setupTestServer(t)
+	defer teardownTestServer(t, srv)
+	// Create cluster as prerequisite
+	c, err := srv.server.clusterManager.Create(types.ClusterCreateOps{Size: 3})
+	if err != nil {
+		t.Error(err)
+	}
+	// Pre-place cluster for name/address conflict
+	srv.server.clusterManager.RegisterNode(
+		c.ID,
+		&types.Node{ID: "4", Name: "node4", AdvertiseAddress: "192.168.0.4", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	)
+	// Parallel test cases
+	testcases := []struct {
+		name      string
+		clusterID string
+		node      types.Node
+		code      int
+		errMsg    string
+	}{
+		{
+			name:      "ok registration - node 1",
+			clusterID: c.ID,
+			node:      types.Node{ID: "1", Name: "node1", AdvertiseAddress: "192.168.0.1", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusOK,
+			errMsg:    "",
+		},
+		{
+			name:      "ok registration - node 2",
+			clusterID: c.ID,
+			node:      types.Node{ID: "2", Name: "node2", AdvertiseAddress: "192.168.0.2", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusOK,
+			errMsg:    "",
+		},
+		{
+			name:      "ok registration - node 3",
+			clusterID: c.ID,
+			node:      types.Node{ID: "3", Name: "node3", AdvertiseAddress: "192.168.0.3", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusOK,
+			errMsg:    "",
+		},
+		{
+			name:      "name already present - node 4",
+			clusterID: c.ID,
+			node:      types.Node{ID: "5", Name: "node4", AdvertiseAddress: "192.168.0.5", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusConflict,
+			errMsg: fmt.Sprintf(
+				"%s: name node4 exists in cluster %s\n",
+				cluster.ErrNodeNamePresent,
+				c.ID,
+			),
+		},
+		{
+			name:      "address already present - 192.168.0.4",
+			clusterID: c.ID,
+			node:      types.Node{ID: "6", Name: "node6", AdvertiseAddress: "192.168.0.4", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusConflict,
+			errMsg: fmt.Sprintf(
+				"%s: address 192.168.0.4 exists in cluster %s\n",
+				cluster.ErrNodeAddressPresent,
+				c.ID,
+			),
+		},
+		{
+			name:      "address missing",
+			clusterID: c.ID,
+			node:      types.Node{ID: "5", Name: "node5", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusBadRequest,
+			errMsg:    fmt.Sprintf("%s\n", cluster.ErrAddressMissing),
+		},
+		{
+			name:      "name missing",
+			clusterID: c.ID,
+			node:      types.Node{ID: "5", AdvertiseAddress: "192.168.0.5", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusBadRequest,
+			errMsg:    fmt.Sprintf("%s\n", cluster.ErrNameMissing),
+		},
+		{
+			name:      "invalid address",
+			clusterID: c.ID,
+			node:      types.Node{ID: "5", Name: "node5", AdvertiseAddress: "192.168.0.5:5555", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusBadRequest,
+			errMsg:    fmt.Sprintf("%s\n", cluster.ErrInvalidAddress),
+		},
+		{
+			name:      "non-existent cluster",
+			clusterID: "123", // non-existent cluster ID
+			node:      types.Node{ID: "5", Name: "node5", AdvertiseAddress: "192.168.0.5", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			code:      http.StatusNotFound,
+			errMsg:    fmt.Sprintf("%s\n", store.ErrNotFound),
+		},
+	}
+
+	// Register nodes correctly
+	registerNode := func(t *testing.T, clusterID string, n types.Node) *httptest.ResponseRecorder {
+		reqBody, err := json.Marshal(n)
+		if err != nil {
+			t.Fatalf("failed to marshal node: %v", err)
+		}
+		req, err := http.NewRequest(http.MethodPut,
+			fmt.Sprintf("/clusters/%s", clusterID),
+			bytes.NewBuffer(reqBody))
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		rec := httptest.NewRecorder()
+
+		srv.server.mux.ServeHTTP(rec, req)
+
+		return rec
+	}
+
+	t.Run("register requests", func(t *testing.T) {
+		for _, tc := range testcases {
+			want := tc // capture
+			t.Run(want.name, func(t *testing.T) {
+				t.Parallel()
+				resp := registerNode(t, want.clusterID, want.node)
+				if resp.Code != want.code {
+					t.Errorf("\ngot code %d\n wanted code %d", resp.Code, want.code)
+				}
+				if want.errMsg != "" {
+					if resp.Body.String() != want.errMsg {
+						t.Errorf("\ngot err:\n %s \n wanted err:\n %s", resp.Body.String(), want.errMsg)
+					}
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
When trying to register a node with a cluster where the address or name is already present, will return a `http.StatusUnprocessableEntity` instead of `http.StatusInternalServerError`. Missing node name errors are now identified and use `http.StatusBadRequest`.